### PR TITLE
Example changes needed for return types

### DIFF
--- a/src/dss/VatAbstract.sol
+++ b/src/dss/VatAbstract.sol
@@ -15,11 +15,10 @@ contract VatAbstract {
     struct Urn {
         uint256 ink;   // Locked Collateral  [wad]
         uint256 art;   // Normalised Debt    [wad]
-    }    
+    }
     mapping (address => mapping (address => uint256)) public can;
     function hope(address) external;
-    function ilks(bytes32) external view returns (Ilk);
-    mapping (bytes32 => Ilk) public ilks;
+    function ilks(bytes32) external view returns (uint256, uint256, uint256, uint256, uint256);
     mapping (bytes32 => mapping (address => Urn)) public urns;
     mapping (bytes32 => mapping (address => uint256)) public gem;  // [wad]
     mapping (address => uint256) public dai;  // [rad]
@@ -30,7 +29,7 @@ contract VatAbstract {
     uint256 public live;  // Access Flag
     function init(bytes32) external;
     function file(bytes32, uint256) external;
-    function file(bytes32, bytes32) external;
+    function file(bytes32, bytes32, uint256) external;
     function cage() external;
     function slip(bytes32, address, int256) external;
     function flux(bytes32, address, address, uint256) external;
@@ -40,6 +39,6 @@ contract VatAbstract {
     function grab(bytes32, address, address, address, int256, int256) external;
     function heal(uint256) external;
     function suck(address, address, uint256) external;
-    function fold(bytes32, address, int256) external;    
+    function fold(bytes32, address, int256) external;
 }
 


### PR DESCRIPTION
This is a minimal start, but contains a few fixes I needed.  When we return the structs, we are going to just have to break those out to constituent types.