### PR TITLE
Add Sai abstracts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity

--- a/src/Interfaces.sol
+++ b/src/Interfaces.sol
@@ -38,5 +38,6 @@ import { SaiMomAbstract } from "./sai/SaiMomAbstract.sol";
 import { SaiTapAbstract } from "./sai/SaiTapAbstract.sol";
 import { SaiTopAbstract } from "./sai/SaiTopAbstract.sol";
 import { SaiTubAbstract } from "./sai/SaiTubAbstract.sol";
+import { SaiVoxAbstract } from "./sai/SaiVoxAbstract.sol";
 
 import { PotHelper } from "./dss/PotHelper.sol";

--- a/src/Interfaces.sol
+++ b/src/Interfaces.sol
@@ -32,4 +32,9 @@ import { SpotAbstract } from "./dss/SpotAbstract.sol";
 import { VatAbstract } from "./dss/VatAbstract.sol";
 import { VowAbstract } from "./dss/VowAbstract.sol";
 
+// Sai
+import { GemPitAbstract } from "./sai/GemPitAbstract.sol";
+import { SaiMomAbstract } from "./sai/SaiMomAbstract.sol";
+import { SaiTapAbstract } from "./sai/SaiTapAbstract.sol";
+
 import { PotHelper } from "./dss/PotHelper.sol";

--- a/src/Interfaces.sol
+++ b/src/Interfaces.sol
@@ -36,6 +36,7 @@ import { VowAbstract } from "./dss/VowAbstract.sol";
 import { GemPitAbstract } from "./sai/GemPitAbstract.sol";
 import { SaiMomAbstract } from "./sai/SaiMomAbstract.sol";
 import { SaiTapAbstract } from "./sai/SaiTapAbstract.sol";
+import { SaiTokenAbstract } from "./sai/SaiTokenAbstract.sol";
 import { SaiTopAbstract } from "./sai/SaiTopAbstract.sol";
 import { SaiTubAbstract } from "./sai/SaiTubAbstract.sol";
 import { SaiVoxAbstract } from "./sai/SaiVoxAbstract.sol";

--- a/src/Interfaces.sol
+++ b/src/Interfaces.sol
@@ -36,5 +36,6 @@ import { VowAbstract } from "./dss/VowAbstract.sol";
 import { GemPitAbstract } from "./sai/GemPitAbstract.sol";
 import { SaiMomAbstract } from "./sai/SaiMomAbstract.sol";
 import { SaiTapAbstract } from "./sai/SaiTapAbstract.sol";
+import { SaiTopAbstract } from "./sai/SaiTopAbstract.sol";
 
 import { PotHelper } from "./dss/PotHelper.sol";

--- a/src/Interfaces.sol
+++ b/src/Interfaces.sol
@@ -37,5 +37,6 @@ import { GemPitAbstract } from "./sai/GemPitAbstract.sol";
 import { SaiMomAbstract } from "./sai/SaiMomAbstract.sol";
 import { SaiTapAbstract } from "./sai/SaiTapAbstract.sol";
 import { SaiTopAbstract } from "./sai/SaiTopAbstract.sol";
+import { SaiTubAbstract } from "./sai/SaiTubAbstract.sol";
 
 import { PotHelper } from "./dss/PotHelper.sol";

--- a/src/dapp/DSRuneAbstract.sol
+++ b/src/dapp/DSRuneAbstract.sol
@@ -25,7 +25,7 @@ contract DSRuneAbstract {
     // @return [bytes32] extcodehash of rune address
     function tag()      public view returns (bytes32);
     // @return [bytes] The `abi.encodeWithSignature()` result of the function to be called.
-    function sig()      public view returns (bytes);
+    function sig()      public view returns (bytes memory);
     // @return [uint256] Earliest time rune can execute
     function eta()      public view returns (uint256);
     // The schedule() function plots the rune in the DSPause

--- a/src/dapp/DSThingAbstract.sol
+++ b/src/dapp/DSThingAbstract.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.5.12;
+
+import { DSAuthAbstract } from "./DSAuthorityAbstract.sol";
+
+// https://github.com/dapphub/ds-thing
+// DS-Thing inherits from DS-Auth, DS-Note, and DS-Math.
+//   Only DS-Auth contains public functions.
+contract DSThingAbstract is DSAuthAbstract {}

--- a/src/sai/GemPitAbstract.sol
+++ b/src/sai/GemPitAbstract.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.5.12;
+
+
+// https://github.com/makerdao/sai/blob/master/src/pit.sol
+contract GemPitAbstract {
+    function burn(address) public;
+}

--- a/src/sai/SaiMomAbstract.sol
+++ b/src/sai/SaiMomAbstract.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.5.12;
+
+import { DSThingAbstract } from "../dapp/DSThingAbstract.sol";
+
+// https://github.com/makerdao/sai/blob/master/src/mom.sol
+contract SaiMomAbstract is DSThingAbstract {
+    // SaiTub  public  tub;
+    function tub() public returns (address);
+    // SaiTap  public  tap;
+    function tap() public returns (address);
+    // SaiVox  public  vox;
+    function vox() public returns (address);
+    function setCap(uint256) public;                  // Debt ceiling
+    function setMat(uint256) public;                  // Liquidation ratio
+    function setTax(uint256) public;                  // Stability fee
+    function setFee(uint256) public;                  // Governance fee
+    function setAxe(uint256) public;                  // Liquidation fee
+    function setTubGap(uint256) public;               // Join/Exit Spread
+    function setPip(address) public;                  // ETH/USD Feed
+    function setPep(address) public;                  // MKR/USD Feed
+    function setVox(address) public;                  // TRFM
+    function setTapGap(uint256) public;               // Boom/Bust Spread
+    function setWay(uint256) public;                  // Rate of change of target price (per second)
+    function setHow(uint256) public;
+    }
+}

--- a/src/sai/SaiMomAbstract.sol
+++ b/src/sai/SaiMomAbstract.sol
@@ -22,5 +22,4 @@ contract SaiMomAbstract is DSThingAbstract {
     function setTapGap(uint256) public;               // Boom/Bust Spread
     function setWay(uint256) public;                  // Rate of change of target price (per second)
     function setHow(uint256) public;
-    }
 }

--- a/src/sai/SaiMomAbstract.sol
+++ b/src/sai/SaiMomAbstract.sol
@@ -5,11 +5,11 @@ import { DSThingAbstract } from "../dapp/DSThingAbstract.sol";
 // https://github.com/makerdao/sai/blob/master/src/mom.sol
 contract SaiMomAbstract is DSThingAbstract {
     // SaiTub  public  tub;
-    function tub() public returns (address);
+    function tub() public view returns (address);
     // SaiTap  public  tap;
-    function tap() public returns (address);
+    function tap() public view returns (address);
     // SaiVox  public  vox;
-    function vox() public returns (address);
+    function vox() public view returns (address);
     function setCap(uint256) public;                  // Debt ceiling
     function setMat(uint256) public;                  // Liquidation ratio
     function setTax(uint256) public;                  // Stability fee

--- a/src/sai/SaiTapAbstract.sol
+++ b/src/sai/SaiTapAbstract.sol
@@ -1,0 +1,34 @@
+pragma solidity ^0.5.12;
+
+import { DSThingAbstract } from "../dapp/DSThingAbstract.sol";
+
+// https://github.com/makerdao/sai/blob/master/src/tap.sol
+contract SaiTapAbstract is DSThingAbstract {
+    // DSToken  public  sai;
+    function sai() public returns (address);
+    // DSToken  public  sin;
+    function sin() public returns (address);
+    // DSToken  public  skr;
+    function skr() public returns (address);
+    // SaiVox   public  vox;
+    function vox() public returns (address);
+    // SaiTub   public  tub;
+    function tub() public returns (address);
+    function gap() public returns (uint256);       // Boom-Bust Spread
+    function off() public returns (bool);          // Cage flag
+    function fix() public returns (uint256);       // Cage price
+    function joy() public view returns (uint256);  // Surplus
+    function woe() public view returns (uint256);  // Bad debt
+    function fog() public view returns (uint256);  // Collateral pending liquidation
+    function mold(bytes32, uint256) public;
+    function heal() public;                        // Cancel debt
+    function s2s() public returns (uint256);       // Feed price (sai per skr)
+    function bid(uint256) public returns (uint256);// Boom price (sai per skr)
+    function ask(uint256) public returns (uint256);// Bust price (sai per skr)
+    function bust(uint256) public;
+    function boom(uint256) public;
+    function cage(uint256) public;
+    function cash(uint256) public;
+    function mock(uint256) public;
+    function vent() public;
+}

--- a/src/sai/SaiTapAbstract.sol
+++ b/src/sai/SaiTapAbstract.sol
@@ -5,18 +5,18 @@ import { DSThingAbstract } from "../dapp/DSThingAbstract.sol";
 // https://github.com/makerdao/sai/blob/master/src/tap.sol
 contract SaiTapAbstract is DSThingAbstract {
     // DSToken  public  sai;
-    function sai() public returns (address);
+    function sai() public view returns (address);
     // DSToken  public  sin;
-    function sin() public returns (address);
+    function sin() public view returns (address);
     // DSToken  public  skr;
-    function skr() public returns (address);
+    function skr() public view returns (address);
     // SaiVox   public  vox;
-    function vox() public returns (address);
+    function vox() public view returns (address);
     // SaiTub   public  tub;
-    function tub() public returns (address);
-    function gap() public returns (uint256);       // Boom-Bust Spread
-    function off() public returns (bool);          // Cage flag
-    function fix() public returns (uint256);       // Cage price
+    function tub() public view returns (address);
+    function gap() public view returns (uint256);       // Boom-Bust Spread
+    function off() public view returns (bool);          // Cage flag
+    function fix() public view returns (uint256);       // Cage price
     function joy() public view returns (uint256);  // Surplus
     function woe() public view returns (uint256);  // Bad debt
     function fog() public view returns (uint256);  // Collateral pending liquidation

--- a/src/sai/SaiTokenAbstract.sol
+++ b/src/sai/SaiTokenAbstract.sol
@@ -1,0 +1,6 @@
+pragma solidity ^0.5.12;
+
+import { DSTokenAbstract } from "../dapp/DSTokenAbstract.sol";
+
+// Sai Token adheres to the DS-Token contract interface
+contract SaiTokenAbstract is DSTokenAbstract {}

--- a/src/sai/SaiTopAbstract.sol
+++ b/src/sai/SaiTopAbstract.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.5.12;
+
+import { DSThingAbstract } from "../dapp/DSThingAbstract.sol";
+
+// https://github.com/makerdao/sai/blob/master/src/top.sol
+contract SaiTopAbstract is DSThingAbstract {
+    // SaiVox   public  vox;
+    function vox() public returns (address);
+    // SaiTub   public  tub;
+    function tub() public returns (address);
+    // SaiTap   public  tap;
+    function tap() public returns (address);
+    // DSToken  public  sai;
+    function sai() public returns (address);
+    // DSToken  public  sin;
+    function sin() public returns (address);
+    // DSToken  public  skr;
+    function skr() public returns (address);
+    // ERC20    public  gem;
+    function gem() public returns (address);
+    // uint256  public  fix;  // sai cage price (gem per sai)
+    function fix() public returns (uint256);
+    // uint256  public  fit;  // skr cage price (ref per skr)
+    function fit() public returns (uint256);
+    // uint256  public  caged;
+    function caged() public returns (uint256);
+    // uint256  public  cooldown = 6 hours;
+    function cooldown() public returns (uint256);
+    function era() public view returns (uint256);
+    function cage() public;
+    function flow() public;
+    function setCooldown(uint256) public;
+}

--- a/src/sai/SaiTopAbstract.sol
+++ b/src/sai/SaiTopAbstract.sol
@@ -5,27 +5,27 @@ import { DSThingAbstract } from "../dapp/DSThingAbstract.sol";
 // https://github.com/makerdao/sai/blob/master/src/top.sol
 contract SaiTopAbstract is DSThingAbstract {
     // SaiVox   public  vox;
-    function vox() public returns (address);
+    function vox() public view returns (address);
     // SaiTub   public  tub;
-    function tub() public returns (address);
+    function tub() public view returns (address);
     // SaiTap   public  tap;
-    function tap() public returns (address);
+    function tap() public view returns (address);
     // DSToken  public  sai;
-    function sai() public returns (address);
+    function sai() public view returns (address);
     // DSToken  public  sin;
-    function sin() public returns (address);
+    function sin() public view returns (address);
     // DSToken  public  skr;
-    function skr() public returns (address);
+    function skr() public view returns (address);
     // ERC20    public  gem;
-    function gem() public returns (address);
+    function gem() public view returns (address);
     // uint256  public  fix;  // sai cage price (gem per sai)
-    function fix() public returns (uint256);
+    function fix() public view returns (uint256);
     // uint256  public  fit;  // skr cage price (ref per skr)
-    function fit() public returns (uint256);
+    function fit() public view returns (uint256);
     // uint256  public  caged;
-    function caged() public returns (uint256);
+    function caged() public view returns (uint256);
     // uint256  public  cooldown = 6 hours;
-    function cooldown() public returns (uint256);
+    function cooldown() public view returns (uint256);
     function era() public view returns (uint256);
     function cage() public;
     function flow() public;

--- a/src/sai/SaiTubAbstract.sol
+++ b/src/sai/SaiTubAbstract.sol
@@ -1,0 +1,86 @@
+pragma solidity ^0.5.12;
+
+import { DSThingAbstract } from "../dapp/DSThingAbstract.sol";
+
+// https://github.com/makerdao/sai/blob/master/src/tub.sol
+contract SaiTubAbstract is DSThingAbstract {
+    // DSToken  public  sai;  // Stablecoin
+    function sai() public view returns (address);
+    // DSToken  public  sin;  // Debt (negative sai)
+    function sin() public view returns (address);
+    // DSToken  public  skr;  // Abstracted collateral
+    function skr() public view returns (address);
+    // ERC20    public  gem;  // Underlying collateral
+    function gem() public view returns (address);
+    // DSToken  public  gov;  // Governance token
+    function gov() public view returns (address);
+    //SaiVox   public  vox;  // Target price feed
+    function vox() public view returns (address);
+    // DSValue  public  pip;  // Reference price feed
+    function pip() public view returns (address);
+    // DSValue  public  pep;  // Governance price feed
+    function pep() public view returns (address);
+    // address  public  tap;  // Liquidator
+    function tap() public view returns (address);
+    // address  public  pit;  // Governance Vault
+    function pit() public view returns (address);
+    // uint256  public  axe;  // Liquidation penalty
+    function axe() public view returns (uint256);
+    // uint256  public  cap;  // Debt ceiling
+    function cap() public view returns (uint256);
+    // uint256  public  mat;  // Liquidation ratio
+    function mat() public view returns (uint256);
+    // uint256  public  tax;  // Stability fee
+    function tax() public view returns (uint256);
+    // uint256  public  fee;  // Governance fee
+    function fee() public view returns (uint256);
+    // uint256  public  gap;  // Join-Exit Spread
+    function gap() public view returns (uint256);
+    // bool     public  off;  // Cage flag
+    function off() public view returns (bool);
+    // bool     public  out;  // Post cage exit
+    function out() public view returns (bool);
+    // uint256  public  fit;  // REF per SKR (just before settlement)
+    function fit() public view returns (uint256);
+    // uint256  public  rho;  // Time of last drip
+    function rho() public view returns (uint256);
+    // uint256  public  rum;  // Total normalised debt
+    function rum() public view returns (uint256);
+    // uint256                   public  cupi;
+    function cupi() public view returns (uint256);
+    // mapping (bytes32 => Cup)  public  cups;
+    function cups(bytes32) public view returns (address, uint256, uint256, uint256);
+    function lad(bytes32) public view returns (address);
+    function ink(bytes32) public view returns (address);
+    function tab(bytes32) public view returns (uint256);
+    function rap(bytes32) public returns (uint256);
+    function din() public returns (uint256);            // Total CDP Debt
+    function air() public view returns (uint256);       // Backing collateral
+    function pie() public view returns (uint256);       // Raw collateral
+    function era() public view returns (uint256);
+    function mold(bytes32, uint256) public;             // Risk parameter config
+    function setPip(address) public;                    // Price feed setter
+    function setPep(address) public;                    // Price feed setter
+    function setVox(address) public;                    // Price feed setter
+    function turn(address) public;                      // Tap setter
+    function per() public view returns (uint256);       // Wrapper ratio (gem per skr)
+    function ask(uint256) public view returns (uint256);// Join price (gem per skr)
+    function bid(uint256) public view returns (uint256);// Exit price (gem per skr)
+    function join(uint256) public;
+    function exit(uint256) public;
+    function chi() public returns (uint256);
+    function rhi() public returns (uint256);
+    function drip() public;
+    function tag() public view returns (uint256);       // Abstracted collateral price (ref per skr)
+    function safe(bytes32) public returns (bool);       // Returns true if cup is well-collateralized
+    function open() public returns (bytes32);
+    function give(bytes32, address) public;
+    function lock(bytes32, uint256) public;
+    function free(bytes32, uint256) public;
+    function draw(bytes32, uint256) public;
+    function wipe(bytes32, uint256) public;
+    function shut(bytes32) public;
+    function bite(bytes32) public;
+    function cage(uint256, uint256) public;
+    function flow() public;
+}

--- a/src/sai/SaiVoxAbstract.sol
+++ b/src/sai/SaiVoxAbstract.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.5.12;
+
+import { DSThingAbstract } from "../dapp/DSThingAbstract.sol";
+
+// https://github.com/makerdao/sai/blob/master/src/vox.sol
+contract SaiVoxAbstract is DSThingAbstract {
+    function fix() public view returns (uint256);
+    function how() public view returns (uint256);
+    function tau() public view returns (uint256);
+    function era() public view returns (uint256);
+    function mold(bytes32, uint256) public;
+    function par() public returns (uint256);  // Dai Target Price (ref per dai)
+    function way() public returns (uint256);
+    function tell(uint256) public;
+    function tune(uint256) public;
+    function prod() public;
+}


### PR DESCRIPTION
Spellcrafters rejoice! 

Adds contract abstracts for Sai GemPit, Mom, Tap, SAI, Top, Tub, and Vox.

Also adds `memory` keyword to DS-Rune interface to fix a compiler bug.