### PR TITLE
Remove unnecessary stuff.

### DIFF
--- a/src/ERC/GemAbstract.sol
+++ b/src/ERC/GemAbstract.sol
@@ -9,6 +9,4 @@ contract GemAbstract {
     function approve(address, uint256) public returns (bool);
     function transfer(address, uint256) public returns (bool);
     function transferFrom(address, address, uint256) public returns (bool);
-    event Approval(address, address, uint256);
-    event Transfer(address, address, uint256);
 }

--- a/src/Interfaces.sol
+++ b/src/Interfaces.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.12;
 
 import { GemAbstract } from "./ERC/GemAbstract.sol";
 
-import { DSAuthorityAbstract, DSAuthEventsAbstract, DSAuthAbstract } from "./dapp/DSAuthorityAbstract.sol";
+import { DSAuthorityAbstract, DSAuthAbstract } from "./dapp/DSAuthorityAbstract.sol";
 import { DSChiefAbstract } from "./dapp/DSChiefAbstract.sol";
 import { DSPauseAbstract } from "./dapp/DSPauseAbstract.sol";
 import { DSPauseProxyAbstract } from "./dapp/DSPauseProxyAbstract.sol";

--- a/src/dapp/DSAuthorityAbstract.sol
+++ b/src/dapp/DSAuthorityAbstract.sol
@@ -5,16 +5,9 @@ contract DSAuthorityAbstract {
     function canCall(address, address, bytes4) public view returns (bool);
 }
 
-contract DSAuthEventsAbstract {
-    event LogSetAuthority (address indexed);
-    event LogSetOwner (address indexed);
-}
-
-contract DSAuthAbstract is DSAuthEventsAbstract {
-    // DSAuthority  public  authority;
-    function authority() public view returns (DSAuthorityAbstract);
-    // address      public  owner;
+contract DSAuthAbstract {
+    function authority() public view returns (address);
     function owner() public view returns (address);
     function setOwner(address) public;
-    function setAuthority(DSAuthorityAbstract) public;
+    function setAuthority(address) public;
 }

--- a/src/dapp/DSChiefAbstract.sol
+++ b/src/dapp/DSChiefAbstract.sol
@@ -2,25 +2,14 @@ pragma solidity ^0.5.12;
 
 // https://github.com/dapphub/ds-chief
 contract DSChiefApprovals {
-    // mapping(bytes32=>address[]) public slates;
     function slates(bytes32) public view returns (address[] memory);
-    // mapping(address=>bytes32) public votes;
     function votes(address) public view returns (bytes32);
-    // mapping(address=>uint256) public approvals;
     function approvals(address) public view returns (uint256);
-    // mapping(address=>uint256) public deposits;
     function deposits(address) public view returns (address);
-    // DSToken public GOV; // voting token that gets locked up
-    // GOV return address will conform to DSTokenAbstract
     function GOV() public view returns (address);
-    // DSToken public IOU; // non-voting representation of a token, for e.g. secondary voting mechanisms
-    // IOU return address will conform to DSTokenAbstract
     function IOU() public view returns (address);
-    // address public hat; // the chieftain's hat
     function hat() public view returns (address);
-    // uint256 public MAX_YAYS;
     function MAX_YAYS() public view returns (uint256);
-    event Etch(bytes32 indexed);
     function lock(uint256) public;
     function free(uint256) public;
     function etch(address[] memory) public returns (bytes32);
@@ -31,19 +20,12 @@ contract DSChiefApprovals {
 
 contract DSChiefAbstract is DSChiefApprovals {
     function setOwner(address) public;
-    // setAuthority address param should conform to DSAuthorityAbstract
     function setAuthority(address) public;
     function isUserRoot(address) public view returns (bool);
     function setRootUser(address, bool) public;
-
-    //// DS-Roles
-    // mapping(address=>bool) _root_users;
     function _root_users(address) public view returns (bool);
-    // mapping(address=>bytes32) _user_roles;
     function _user_roles(address) public view returns (bytes32);
-    // mapping(address=>mapping(bytes4=>bytes32)) _capability_roles;
     function _capability_roles(address, bytes4) public view returns (bytes32);
-    // mapping(address=>mapping(bytes4=>bool)) _public_capabilities;
     function _public_capabilities(address, bytes4) public view returns (bool);
     function getUserRoles(address) public view returns (bytes32);
     function getCapabilityRoles(address, bytes4) public view returns (bytes32);
@@ -56,7 +38,5 @@ contract DSChiefAbstract is DSChiefApprovals {
 }
 
 contract DSChiefFabAbstract {
-    // newChief address param should conform to DSTokenAbstract
-    // newChief return address should conform to DSChiefAbstract
     function newChief(address, uint256) public returns (address);
 }

--- a/src/dapp/DSPauseAbstract.sol
+++ b/src/dapp/DSPauseAbstract.sol
@@ -3,14 +3,10 @@ pragma solidity ^0.5.12;
 // https://github.com/dapphub/ds-pause
 contract DSPauseAbstract {
     function setOwner(address) public;
-    // setAuthority address should conform to DSAuthorityAbstract
     function setAuthority(address) public;
     function setDelay(uint256) public;
-    // mapping (bytes32 => bool) public plans;
     function plans(bytes32) public view returns (bool);
-    // DSPauseProxyAbstract public proxy;
     function proxy() public view returns (address);
-    // uint256 public delay;
     function delay() public view returns (uint256);
     function plot(address, bytes32, bytes memory, uint256) public;
     function drop(address, bytes32, bytes memory, uint256) public;

--- a/src/dapp/DSPauseProxyAbstract.sol
+++ b/src/dapp/DSPauseProxyAbstract.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.5.12;
 
 // https://github.com/dapphub/ds-pause
 contract DSPauseProxyAbstract {
-    // address public owner;
     function owner() public view returns (address);
     function exec(address, bytes memory) public returns (bytes memory);
 }

--- a/src/dapp/DSRolesAbstract.sol
+++ b/src/dapp/DSRolesAbstract.sol
@@ -2,13 +2,9 @@ pragma solidity ^0.5.12;
 
 // https://github.com/dapphub/ds-roles
 contract DSRolesAbstract {
-    // mapping(address=>bool) _root_users;
     function _root_users(address) public view returns (bool);
-    // mapping(address=>bytes32) _user_roles;
     function _user_roles(address) public view returns (bytes32);
-    // mapping(address=>mapping(bytes4=>bytes32)) _capability_roles;
     function _capability_roles(address, bytes4) public view returns (bytes32);
-    // mapping(address=>mapping(bytes4=>bool)) _public_capabilities;
     function _public_capabilities(address, bytes4) public view returns (bool);
     function getUserRoles(address) public view returns (bytes32);
     function getCapabilityRoles(address, bytes4) public view returns (bytes32);
@@ -20,10 +16,7 @@ contract DSRolesAbstract {
     function setUserRole(address, uint8, bool) public;
     function setPublicCapability(address, bytes4, bool) public;
     function setRoleCapability(uint8, address, bytes4, bool) public;
-    // ds-auth
-    // DSAuthority  public  authority;
     function authority() public view returns (address);
-    // address      public  owner;
     function owner() public view returns (address);
     function setOwner(address) public;
     function setAuthority(address) public;

--- a/src/dapp/DSSpellAbstract.sol
+++ b/src/dapp/DSSpellAbstract.sol
@@ -2,13 +2,9 @@ pragma solidity ^0.5.12;
 
 // https://github.com/dapphub/ds-spell
 contract DSSpellAbstract {
-    // address public whom;
     function whom() public view returns (address);
-    // uint256 public mana;
     function mana() public view returns (uint256);
-    // bytes   public data;
     function data() public view returns (bytes memory);
-    //bool    public done;
     function done() public view returns (bool);
     function cast() public;
 }

--- a/src/dapp/DSThingAbstract.sol
+++ b/src/dapp/DSThingAbstract.sol
@@ -1,12 +1,8 @@
 pragma solidity ^0.5.12;
 
 // https://github.com/dapphub/ds-thing
-// DS-Thing inherits from DS-Auth, DS-Note, and DS-Math.
-//   Only DS-Auth contains public functions.
 contract DSThingAbstract {
-    // DSAuthority  public  authority;
     function authority() public view returns (address);
-    // address      public  owner;
     function owner() public view returns (address);
     function setOwner(address) public;
     function setAuthority(address) public;

--- a/src/dapp/DSTokenAbstract.sol
+++ b/src/dapp/DSTokenAbstract.sol
@@ -1,13 +1,9 @@
 pragma solidity ^0.5.12;
 
-// MKR Token adheres to the DSToken interface
 // https://github.com/dapphub/ds-token/blob/master/src/token.sol
 contract DSTokenAbstract {
-    // bytes32 public name;
     function name() public view returns (bytes32);
-    // bytes32 public symbol;
     function symbol() public view returns (bytes32);
-    // uint256 public decimals;
     function decimals() public view returns (uint256);
     function totalSupply() external view returns (uint256);
     function balanceOf(address) external view returns (uint256);
@@ -24,12 +20,7 @@ contract DSTokenAbstract {
     function burn(uint256) public;
     function burn(address,uint) public;
     function setName(bytes32) public;
-    event Transfer(address, address, uint256);
-    event Approval(address, address, uint256);
-    // DSToken Inherits DSAuth
-    // DSAuthority  public  authority;
     function authority() public view returns (address);
-    // address      public  owner;
     function owner() public view returns (address);
     function setOwner(address) public;
     function setAuthority(address) public;

--- a/src/dapp/DSValueAbstract.sol
+++ b/src/dapp/DSValueAbstract.sol
@@ -2,17 +2,13 @@ pragma solidity ^0.5.12;
 
 // https://github.com/dapphub/ds-value/blob/master/src/value.sol
 contract DSValueAbstract {
-    // bool public has;
     function has() public view returns (bool);
-    // bytes32 public val;
     function val() public view returns (bytes32);
     function peek() public view returns (bytes32, bool);
     function read() public view returns (bytes32);
     function poke(bytes32) public;
     function void() public;
-    // DSAuthority  public  authority;
     function authority() public view returns (address);
-    // address      public  owner;
     function owner() public view returns (address);
     function setOwner(address) public;
     function setAuthority(address) public;

--- a/src/dss/AuthGemJoinAbstract.sol
+++ b/src/dss/AuthGemJoinAbstract.sol
@@ -2,18 +2,11 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss-deploy/blob/master/src/join.sol
 contract AuthGemJoinAbstract {
-    // VatAbstract public vat;
     function vat() public view returns (address);
-    // bytes32 public ilk;
     function ilk() public view returns (bytes32);
-    // TokenAbstract public gem;
-    // gem return address will conform to DSTokenAbstract
     function gem() public view returns (address);
-    // uint256 public dec;
     function dec() public view returns (uint256);
-    // uint256 public live;  // Access Flag
     function live() public view returns (uint256);
-    // mapping (address => uint) public wards;
     function wards(address) public view returns (uint256);
     function rely(address) public;
     function deny(address) public;

--- a/src/dss/CatAbstract.sol
+++ b/src/dss/CatAbstract.sol
@@ -9,7 +9,6 @@ contract CatAbstract {
     function live() public view returns (uint256);
     function vat() public view returns (address);
     function vow() public view returns (address);
-    function ONE() public returns (uint256);
     function file(bytes32, address) external;
     function file(bytes32, bytes32, uint256) external;
     function file(bytes32, bytes32, address) external;

--- a/src/dss/CatAbstract.sol
+++ b/src/dss/CatAbstract.sol
@@ -2,25 +2,13 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/cat.sol
 contract CatAbstract {
-    // mapping (address => uint) public wards;
     function wards(address) public view returns (uint256);
     function rely(address) external;
     function deny(address) external;
-    struct Ilk {
-        address flip;  // Liquidator
-        uint256 chop;  // Liquidation Penalty   [ray]
-        uint256 lump;  // Liquidation Quantity  [wad]
-    }
-    // mapping (bytes32 => Ilk) public ilks;
     function ilks(bytes32) public view returns (address, uint256, uint256);
-    // uint256 public live;
     function live() public view returns (uint256);
-    // VatAbstract public vat;
     function vat() public view returns (address);
-    // VowAbstract public vow;
     function vow() public view returns (address);
-    event Bite(bytes32, address, uint256, uint256, uint256, address, uint256);
-    // uint256 public ONE;
     function ONE() public returns (uint256);
     function file(bytes32, address) external;
     function file(bytes32, bytes32, uint256) external;

--- a/src/dss/DaiAbstract.sol
+++ b/src/dss/DaiAbstract.sol
@@ -2,31 +2,18 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/dai.sol
 contract DaiAbstract {
-    // mapping (address => uint) public wards;
     function wards(address) public view returns (uint256);
     function rely(address) external;
     function deny(address) external;
-    // string  public constant name;
     function name() public view returns (string memory);
-    // string  public constant symbol;
     function symbol() public view returns (string memory);
-    // string  public constant version;
     function version() public view returns (string memory);
-    // uint8   public constant decimals;
     function decimals() public view returns (uint8);
-    // uint256 public totalSupply;
     function totalSupply() public view returns (uint256);
-    // mapping (address => uint256) public balanceOf;
     function balanceOf(address) public view returns (uint256);
-    // mapping (address => mapping (address => uint256)) public allowance;
     function allowance(address, address) public view returns (uint256);
-    // mapping (address => uint256) public nonces;
     function nonces(address) public view returns (uint256);
-    event Approval(address, address, uint256);
-    event Transfer(address, address, uint256);
-    // bytes32 public DOMAIN_SEPARATOR;
     function DOMAIN_SEPARATOR() public view returns (bytes32);
-    // bytes32 public constant PERMIT_TYPEHASH;
     function PERMIT_TYPEHASH() public view returns (bytes32);
     function transfer(address, uint256) external;
     function transferFrom(address, address, uint256) public returns (bool);

--- a/src/dss/DaiJoinAbstract.sol
+++ b/src/dss/DaiJoinAbstract.sol
@@ -2,19 +2,13 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/join.sol
 contract DaiJoinAbstract {
-    // mapping (address => uint) public wards;
     function wards(address) public view returns (uint256);
     function rely(address usr) external;
     function deny(address usr) external;
-    // VatAbstract public vat;
     function vat() public view returns (address);
-    // DaiAbstract public dai;
     function dai() public view returns (address);
-    // uint256 public live; // Access Flag
     function live() public view returns (uint256);
     function cage() external;
-    // uint256 public ONE;
-    function ONE() public view returns (uint256);
     function join(address, uint256) external;
     function exit(address, uint256) external;
 }

--- a/src/dss/ESMAbstract.sol
+++ b/src/dss/ESMAbstract.sol
@@ -2,21 +2,12 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/esm/blob/master/src/ESM.sol
 contract ESMAbstract {
-    // GemLike public gem; // collateral
-    // gem return address will conform to GemAbstract
     function gem() public view returns (address);
-    // EndLike public end; // cage module
-    // end return address will conform to EndAbstract
     function end() public view returns (address);
-    // address public pit; // burner
     function pit() public view returns (address);
-    // uint256 public min; // threshold
     function min() public view returns (uint256);
-    // uint256 public fired;
     function fired() public view returns (uint256);
-    // mapping(address => uint256) public sum; // per-address balance
     function sum(address) public view returns (address);
-    // uint256 public Sum; // total balance
     function Sum() public view returns (uint256);
     function fire() external;
     function join(uint256) external;

--- a/src/dss/ETHJoinAbstract.sol
+++ b/src/dss/ETHJoinAbstract.sol
@@ -2,15 +2,11 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/join.sol
 contract ETHJoinAbstract {
-    // mapping (address => uint) public wards;
     function wards(address) public view returns (uint256);
     function rely(address usr) external;
     function deny(address usr) external;
-    // VatAbstract public vat;
     function vat() public view returns (address);
-    // bytes32 public ilk;
     function ilk() public view returns (bytes32);
-    // uint256 public live; // Access Flag
     function live() public view returns (uint256);
     function cage() external;
     function join(address) external payable;

--- a/src/dss/EndAbstract.sol
+++ b/src/dss/EndAbstract.sol
@@ -2,43 +2,25 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/end.sol
 contract EndAbstract {
-    // mapping (address => uint) public wards;
     function wards(address) public view returns (uint256);
     function rely(address) external;
     function deny(address) external;
-    // VatAbstract public vat;
     function vat() public view returns (address);
-    // CatAbstract public cat;
     function cat() public view returns (address);
-    // VowAbstract public vow;
     function vow() public view returns (address);
-    // PotAbstract public pot;
     function pot() public view returns (address);
-    // SpotAbstract public spot;
     function spot() public view returns (address);
-    // uint256  public live;  // cage flag
     function live() public view returns (uint256);
-    // uint256  public when;  // time of cage
     function when() public view returns (uint256);
-    //uint256  public wait;  // processing cooldown length
     function wait() public view returns (uint256);
-    // uint256  public debt;  // total outstanding dai following processing [rad]
     function debt() public view returns (uint256);
-    // mapping (bytes32 => uint256) public tag;  // cage price           [ray]
     function tag(bytes32) public view returns (uint256);
-    // mapping (bytes32 => uint256) public gap;  // collateral shortfall [wad]
     function gap(bytes32) public view returns (uint256);
-    // mapping (bytes32 => uint256) public Art;  // total debt per ilk   [wad]
     function Art(bytes32) public view returns (uint256);
-    // mapping (bytes32 => uint256) public fix;  // final cash price     [ray]
     function fix(bytes32) public view returns (uint256);
-    // mapping (address => uint256) public bag;  // [wad]
     function bag(address) public view returns (uint256);
-    // mapping (bytes32 => mapping (address => uint256)) public out;  // [wad]
     function out(bytes32, address) public view returns (uint256);
-    // uint256 public WAD;
     function WAD() public view returns (uint256);
-    // uint256 public RAY;
     function RAY() public view returns (uint256);
     function file(bytes32, address) external;
     function file(bytes32, uint256) external;

--- a/src/dss/FlapAbstract.sol
+++ b/src/dss/FlapAbstract.sol
@@ -2,37 +2,18 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/flap.sol
 contract FlapAbstract {
-    //mapping (address => uint256) public wards;
     function wards(address) public view returns (uint256);
     function rely(address) external;
     function deny(address) external;
-    struct Bid {
-        uint256 bid;
-        uint256 lot;
-        address guy;  // high bidder
-        uint48  tic;  // expiry time
-        uint48  end;
-    }
-    // mapping (uint256 => Bid) public bids;
     function bids(uint256) public view returns (uint256, uint256, address, uint48, uint48);
-    // VatAbstract public vat;
     function vat() public view returns (address);
-    // TokenAbstract public gem;
-    // gem return address will conform to DSTokenAbstract
     function gem() public view returns (address);
-    // uint256 public ONE;
     function ONE() public view returns (uint256);
-    // uint256 public beg;
     function beg() public view returns (uint256);
-    // uint48 public ttl;
     function ttl() public view returns (uint48);
-    // uint48 public tau;
     function tau() public view returns (uint48);
-    // uint256 public kicks;
     function kicks() public view returns (uint256);
-    // uint256 public live;
     function live() public view returns (uint256);
-    event Kick(uint256, uint256, uint256);
     function file(bytes32, uint256) external;
     function kick(uint256, uint256) external returns (uint256);
     function tick(uint256) external;

--- a/src/dss/FlapAbstract.sol
+++ b/src/dss/FlapAbstract.sol
@@ -8,7 +8,6 @@ contract FlapAbstract {
     function bids(uint256) public view returns (uint256, uint256, address, uint48, uint48);
     function vat() public view returns (address);
     function gem() public view returns (address);
-    function ONE() public view returns (uint256);
     function beg() public view returns (uint256);
     function ttl() public view returns (uint48);
     function tau() public view returns (uint48);

--- a/src/dss/FlipAbstract.sol
+++ b/src/dss/FlipAbstract.sol
@@ -8,7 +8,6 @@ contract FlipAbstract {
     function bids(uint256) public view returns (uint256, uint256, address, uint48, uint48, address, address, uint256);
     function vat() public view returns (address);
     function ilk() public view returns (bytes32);
-    function ONE() public view returns (uint256);
     function beg() public view returns (uint256);
     function ttl() public view returns (uint48);
     function tau() public view returns (uint48);

--- a/src/dss/FlipAbstract.sol
+++ b/src/dss/FlipAbstract.sol
@@ -2,37 +2,17 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/flip.sol
 contract FlipAbstract {
-    // mapping (address => uint) public wards;
     function wards(address) public view returns (uint256);
     function rely(address usr) external;
     function deny(address usr) external;
-    struct Bid {
-        uint256 bid;
-        uint256 lot;
-        address guy;  // high bidder
-        uint48  tic;  // expiry time
-        uint48  end;
-        address usr;
-        address gal;
-        uint256 tab;
-    }
-    // mapping (uint => Bid) public bids;
     function bids(uint256) public view returns (uint256, uint256, address, uint48, uint48, address, address, uint256);
-    // VatAbstract public vat;
     function vat() public view returns (address);
-    // bytes32 public ilk;
     function ilk() public view returns (bytes32);
-    // uint256 constant ONE;
     function ONE() public view returns (uint256);
-    // uint256 public beg;
     function beg() public view returns (uint256);
-    // uint48  public ttl;
     function ttl() public view returns (uint48);
-    // uint48  public tau;
     function tau() public view returns (uint48);
-    // uint256 public kicks;
     function kicks() public view returns (uint256);
-    event Kick(uint256, uint256, uint256, uint256, address, address);
     function file(bytes32, uint256) external;
     function kick(address, address, uint256, uint256, uint256) public returns (uint256);
     function tick(uint256) external;

--- a/src/dss/FlopAbstract.sol
+++ b/src/dss/FlopAbstract.sol
@@ -2,41 +2,20 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/flop.sol
 contract FlopAbstract {
-    // mapping (address => uint256) public wards;
     function wards(address) public view returns (uint256);
     function rely(address) external;
     function deny(address) external;
-    struct Bid {
-        uint256 bid;
-        uint256 lot;
-        address guy;  // high bidder
-        uint48  tic;  // expiry time
-        uint48  end;
-    }
-    // mapping (uint => Bid) public bids;
     function bids(uint256) public view returns (uint256, uint256, address, uint48, uint48);
-    //VatAbstract public vat;
     function vat() public view returns (address);
-    // TokenAbstract public gem;
-    // gem return address will conform to DSTokenAbstract
     function gem() public view returns (address);
-    // uint256 public ONE;
     function ONE() public view returns (uint256);
-    // uint256 public beg;  // 5% minimum bid increase
     function beg() public view returns (uint256);
-    // uint256 public pad;  // 50% lot increase for tick
     function pad() public view returns (uint256);
-    // uint48 public ttl;  // 3 hours bid lifetime
     function ttl() public view returns (uint48);
-    // uint48 public tau;   // 2 days total auction length
     function tau() public view returns (uint48);
-    // uint256 public kicks;
     function kicks() public view returns (uint256);
-    // uint256 public live;
     function live() public view returns (uint256);
-    // address public vow;
     function vow() public view returns (address);
-    event Kick(uint256, uint256, uint256, address);
     function file(bytes32, uint256) external;
     function kick(address, uint256, uint256) external returns (uint256);
     function tick(uint256) external;

--- a/src/dss/FlopAbstract.sol
+++ b/src/dss/FlopAbstract.sol
@@ -8,7 +8,6 @@ contract FlopAbstract {
     function bids(uint256) public view returns (uint256, uint256, address, uint48, uint48);
     function vat() public view returns (address);
     function gem() public view returns (address);
-    function ONE() public view returns (uint256);
     function beg() public view returns (uint256);
     function pad() public view returns (uint256);
     function ttl() public view returns (uint48);

--- a/src/dss/GemJoinAbstract.sol
+++ b/src/dss/GemJoinAbstract.sol
@@ -2,19 +2,13 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/join.sol
 contract GemJoinAbstract {
-    // mapping (address => uint) public wards;
     function wards(address) public view returns (uint256);
     function rely(address) external;
     function deny(address) external;
-    // VatAbstract public vat;
     function vat() public view returns (address);
-    // bytes32 public ilk;
     function ilk() public view returns (bytes32);
-    // GemAbstract public gem;
     function gem() public view returns (address);
-    // uint public dec;
     function dec() public view returns (uint256);
-    // uint public live;  // Access Flag
     function live() public view returns (uint256);
     function cage() external;
     function join(address, uint256) external;

--- a/src/dss/JugAbstract.sol
+++ b/src/dss/JugAbstract.sol
@@ -2,24 +2,13 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/jug.sol
 contract JugAbstract {
-    // mapping (address => uint) public wards;
     function wards(address) public view returns (uint256);
     function rely(address) external;
     function deny(address) external;
-    struct Ilk {
-        uint256 duty;
-        uint256  rho;
-    }
-    // mapping (bytes32 => Ilk) public ilks;
     function ilks(bytes32) public view returns (uint256, uint256);
-    // VatLike public vat;
     function vat() public view returns (address);
-    // address public vow;
     function vow() public view returns (address);
-    // uint256 public base;
     function base() public view returns (address);
-    // uint256 constant ONE = 10 ** 27;
-    function ONE() public view returns (uint256);
     function init(bytes32) external;
     function file(bytes32, bytes32, uint256) external;
     function file(bytes32, uint256) external;

--- a/src/dss/OsmAbstract.sol
+++ b/src/dss/OsmAbstract.sol
@@ -2,31 +2,16 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/osm
 contract OsmAbstract {
-    // mapping (address => uint) public wards;
     function wards(address) public view returns (uint256);
     function rely(address) external;
     function deny(address) external;
-    // uint256 public stopped;
     function stopped() public view returns (uint256);
-    // address public src;
     function src() public view returns (address);
-    // uint16  constant ONE_HOUR = uint16(3600);
-    function ONE_HOUR() public view returns (uint16);
-    // uint16  public hop = ONE_HOUR;
     function hop() public view returns (uint16);
-    // uint64  public zzz;
     function zzz() public view returns (uint64);
-    struct Feed {
-        uint128 val;
-        uint128 has;
-    }
-    // Feed cur;
     function cur() public view returns (uint128, uint128);
-    // Feed nxt;
     function nxt() public view returns (uint128, uint128);
-    // mapping (address => uint256) public bud;
     function bud(address) public view returns (uint256);
-    event LogValue(bytes32);
     function stop() external;
     function start() external;
     function change(address) external;

--- a/src/dss/OsmMomAbstract.sol
+++ b/src/dss/OsmMomAbstract.sol
@@ -3,11 +3,8 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/osm-mom
 contract OsmMomAbstract {
-    // address public owner;
     function owner() public view returns (address);
-    // address public authority;
     function authority() public view returns (address);
-    // mapping (bytes32 => address) public osms;
     function osms(bytes32) public view returns (address);
     function setOsm(bytes32, address) public;
     function setOwner(address) public;

--- a/src/dss/PotAbstract.sol
+++ b/src/dss/PotAbstract.sol
@@ -2,25 +2,16 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/pot.sol
 contract PotAbstract {
-    // mapping (address => uint256) public wards;
     function wards(address) public view returns (uint256);
     function rely(address) external;
     function deny(address) external;
-    // mapping (address => uint256) public pie;  // user Savings Dai
     function pie(address) public view returns (uint256);
-    // uint256 public Pie;  // total Savings Dai
     function Pie() public view returns (uint256);
-    // uint256 public dsr;  // the Dai Savings Rate
     function dsr() public view returns (uint256);
-    // uint256 public chi;  // the Rate Accumulator
     function chi() public view returns (uint256);
-    // VatAbstract public vat;  // CDP engine
     function vat() public view returns (address);
-    // address public vow;  // debt engine
     function vow() public view returns (address);
-    // uint256 public rho;  // time of last drip
     function rho() public view returns (uint256);
-    // uint256 public live;  // Access Flag
     function live() public view returns (uint256);
     function file(bytes32, uint256) external;
     function file(bytes32, address) external;

--- a/src/dss/SpotAbstract.sol
+++ b/src/dss/SpotAbstract.sol
@@ -2,25 +2,13 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/spot.sol
 contract SpotAbstract {
-    // mapping (address => uint) public wards;
     function wards(address) public view returns (uint256);
     function rely(address) external;
     function deny(address) external;
-    struct Ilk {
-        address pip;
-        uint256 mat;
-    }
-    // mapping (bytes32 => Ilk) public ilks;
-    // ilks return address will conform to PipAbstract
     function ilks(bytes32) public view returns (address, uint256);
-    // VatAbstract public vat;
     function vat() public view returns (address);
-    // uint256 public par; // ref per dai
     function par() public view returns (uint256);
-    // uint256 public live;
     function live() public view returns (uint256);
-    event Poke(bytes32, bytes32, uint256);
-    // uint256 public ONE;
     function ONE() public view returns (uint256);
     function file(bytes32, bytes32, address) external;
     function file(bytes32, uint256) external;

--- a/src/dss/SpotAbstract.sol
+++ b/src/dss/SpotAbstract.sol
@@ -9,7 +9,6 @@ contract SpotAbstract {
     function vat() public view returns (address);
     function par() public view returns (uint256);
     function live() public view returns (uint256);
-    function ONE() public view returns (uint256);
     function file(bytes32, bytes32, address) external;
     function file(bytes32, uint256) external;
     function file(bytes32, bytes32, uint256) external;

--- a/src/dss/VatAbstract.sol
+++ b/src/dss/VatAbstract.sol
@@ -2,42 +2,20 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/vat.sol
 contract VatAbstract {
-    // mapping (address => uint) public wards;
     function wards(address) public view returns (uint256);
     function rely(address) external;
     function deny(address) external;
-    struct Ilk {
-        uint256 Art;   // Total Normalised Debt     [wad]
-        uint256 rate;  // Accumulated Rates         [ray]
-        uint256 spot;  // Price with Safety Margin  [ray]
-        uint256 line;  // Debt Ceiling              [rad]
-        uint256 dust;  // Urn Debt Floor            [rad]
-    }
-    struct Urn {
-        uint256 ink;   // Locked Collateral  [wad]
-        uint256 art;   // Normalised Debt    [wad]
-    }
-    // mapping (address => mapping (address => uint256)) public can;
     function can(address, address) public view returns (uint256);
     function hope(address) external;
     function nope(address) external;
-    // mapping (bytes32 => Ilk) public ilks;
     function ilks(bytes32) external view returns (uint256, uint256, uint256, uint256, uint256);
-    // mapping (bytes32 => mapping (address => Urn)) public urns;
     function urns(bytes32, address) public view returns (uint256, uint256);
-    // mapping (bytes32 => mapping (address => uint256)) public gem;  // [wad]
     function gem(bytes32, address) public view returns (uint256);
-    // mapping (address => uint256) public dai;  // [rad]
     function dai(address) public view returns (uint256);
-    // mapping (address => uint256) public sin;  // [rad]
     function sin(address) public view returns (uint256);
-    // uint256 public debt;  // Total Dai Issued    [rad]
     function debt() public view returns (uint256);
-    // uint256 public vice;  // Total Unbacked Dai  [rad]
     function vice() public view returns (uint256);
-    // uint256 public Line;  // Total Debt Ceiling  [rad]
     function Line() public view returns (uint256);
-    // uint256 public live;  // Access Flag
     function live() public view returns (uint256);
     function init(bytes32) external;
     function file(bytes32, uint256) external;
@@ -53,4 +31,3 @@ contract VatAbstract {
     function suck(address, address, uint256) external;
     function fold(bytes32, address, int256) external;
 }
-

--- a/src/dss/VowAbstract.sol
+++ b/src/dss/VowAbstract.sol
@@ -2,33 +2,20 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/vow.sol
 contract VowAbstract {
-    // mapping (address => uint) public wards;
     function wards(address) public view returns (uint256);
     function rely(address usr) external;
     function deny(address usr) external;
-    // VatAbstract public vat;
     function vat() public view returns (address);
-    // FlapAbstract public flapper;
     function flapper() public view returns (address);
-    // FlopAbstract public flopper;
     function flopper() public view returns (address);
-    // mapping (uint256 => uint256) public sin; // debt queue
     function sin(uint256) public view returns (uint256);
-    // uint256 public Sin;   // queued debt          [rad]
     function Sin() public view returns (uint256);
-    // uint256 public Ash;
     function Ash() public view returns (uint256);
-    // uint256 public wait;  // flop delay
     function wait() public view returns (uint256);
-    // uint256 public dump;  // flop initial lot size  [wad]
     function dump() public view returns (uint256);
-    // uint256 public sump;  // flop fixed bid size    [rad]
     function sump() public view returns (uint256);
-    // uint256 public bump;  // flap fixed lot size    [rad]
     function bump() public view returns (uint256);
-    // uint256 public hump;  // surplus buffer       [rad]
     function hump() public view returns (uint256);
-    // uint256 public live;
     function live() public view returns (uint256);
     function file(bytes32, uint256) external;
     function file(bytes32, address) external;

--- a/src/sai/GemPitAbstract.sol
+++ b/src/sai/GemPitAbstract.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.12;
 
-
 // https://github.com/makerdao/sai/blob/master/src/pit.sol
 contract GemPitAbstract {
     function burn(address) public;

--- a/src/sai/SaiMomAbstract.sol
+++ b/src/sai/SaiMomAbstract.sol
@@ -2,28 +2,22 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/sai/blob/master/src/mom.sol
 contract SaiMomAbstract {
-    // SaiTub  public  tub;
     function tub() public view returns (address);
-    // SaiTap  public  tap;
     function tap() public view returns (address);
-    // SaiVox  public  vox;
     function vox() public view returns (address);
-    function setCap(uint256) public;                  // Debt ceiling
-    function setMat(uint256) public;                  // Liquidation ratio
-    function setTax(uint256) public;                  // Stability fee
-    function setFee(uint256) public;                  // Governance fee
-    function setAxe(uint256) public;                  // Liquidation fee
-    function setTubGap(uint256) public;               // Join/Exit Spread
-    function setPip(address) public;                  // ETH/USD Feed
-    function setPep(address) public;                  // MKR/USD Feed
-    function setVox(address) public;                  // TRFM
-    function setTapGap(uint256) public;               // Boom/Bust Spread
-    function setWay(uint256) public;                  // Rate of change of target price (per second)
+    function setCap(uint256) public;
+    function setMat(uint256) public;
+    function setTax(uint256) public;
+    function setFee(uint256) public;
+    function setAxe(uint256) public;
+    function setTubGap(uint256) public;
+    function setPip(address) public;
+    function setPep(address) public;
+    function setVox(address) public;
+    function setTapGap(uint256) public;
+    function setWay(uint256) public;
     function setHow(uint256) public;
-    // ds-thing
-    // DSAuthority  public  authority;
     function authority() public view returns (address);
-    // address      public  owner;
     function owner() public view returns (address);
     function setOwner(address) public;
     function setAuthority(address) public;

--- a/src/sai/SaiTapAbstract.sol
+++ b/src/sai/SaiTapAbstract.sol
@@ -2,37 +2,29 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/sai/blob/master/src/tap.sol
 contract SaiTapAbstract {
-    // DSToken  public  sai;
     function sai() public view returns (address);
-    // DSToken  public  sin;
     function sin() public view returns (address);
-    // DSToken  public  skr;
     function skr() public view returns (address);
-    // SaiVox   public  vox;
     function vox() public view returns (address);
-    // SaiTub   public  tub;
     function tub() public view returns (address);
-    function gap() public view returns (uint256);       // Boom-Bust Spread
-    function off() public view returns (bool);          // Cage flag
-    function fix() public view returns (uint256);       // Cage price
-    function joy() public view returns (uint256);  // Surplus
-    function woe() public view returns (uint256);  // Bad debt
-    function fog() public view returns (uint256);  // Collateral pending liquidation
+    function gap() public view returns (uint256);
+    function off() public view returns (bool);
+    function fix() public view returns (uint256);
+    function joy() public view returns (uint256);
+    function woe() public view returns (uint256);
+    function fog() public view returns (uint256);
     function mold(bytes32, uint256) public;
-    function heal() public;                        // Cancel debt
-    function s2s() public returns (uint256);       // Feed price (sai per skr)
-    function bid(uint256) public returns (uint256);// Boom price (sai per skr)
-    function ask(uint256) public returns (uint256);// Bust price (sai per skr)
+    function heal() public;
+    function s2s() public returns (uint256);
+    function bid(uint256) public returns (uint256);
+    function ask(uint256) public returns (uint256);
     function bust(uint256) public;
     function boom(uint256) public;
     function cage(uint256) public;
     function cash(uint256) public;
     function mock(uint256) public;
     function vent() public;
-    // ds-thing
-    // DSAuthority  public  authority;
     function authority() public view returns (address);
-    // address      public  owner;
     function owner() public view returns (address);
     function setOwner(address) public;
     function setAuthority(address) public;

--- a/src/sai/SaiTopAbstract.sol
+++ b/src/sai/SaiTopAbstract.sol
@@ -2,36 +2,22 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/sai/blob/master/src/top.sol
 contract SaiTopAbstract {
-    // SaiVox   public  vox;
     function vox() public view returns (address);
-    // SaiTub   public  tub;
     function tub() public view returns (address);
-    // SaiTap   public  tap;
     function tap() public view returns (address);
-    // DSToken  public  sai;
     function sai() public view returns (address);
-    // DSToken  public  sin;
     function sin() public view returns (address);
-    // DSToken  public  skr;
     function skr() public view returns (address);
-    // ERC20    public  gem;
     function gem() public view returns (address);
-    // uint256  public  fix;  // sai cage price (gem per sai)
     function fix() public view returns (uint256);
-    // uint256  public  fit;  // skr cage price (ref per skr)
     function fit() public view returns (uint256);
-    // uint256  public  caged;
     function caged() public view returns (uint256);
-    // uint256  public  cooldown = 6 hours;
     function cooldown() public view returns (uint256);
     function era() public view returns (uint256);
     function cage() public;
     function flow() public;
     function setCooldown(uint256) public;
-    // ds-thing
-    // DSAuthority  public  authority;
     function authority() public view returns (address);
-    // address      public  owner;
     function owner() public view returns (address);
     function setOwner(address) public;
     function setAuthority(address) public;

--- a/src/sai/SaiTubAbstract.sol
+++ b/src/sai/SaiTubAbstract.sol
@@ -2,75 +2,52 @@ pragma solidity ^0.5.12;
 
 // https://github.com/makerdao/sai/blob/master/src/tub.sol
 contract SaiTubAbstract {
-    // DSToken  public  sai;  // Stablecoin
     function sai() public view returns (address);
-    // DSToken  public  sin;  // Debt (negative sai)
     function sin() public view returns (address);
-    // DSToken  public  skr;  // Abstracted collateral
     function skr() public view returns (address);
-    // ERC20    public  gem;  // Underlying collateral
     function gem() public view returns (address);
-    // DSToken  public  gov;  // Governance token
     function gov() public view returns (address);
-    // SaiVox   public  vox;  // Target price feed
     function vox() public view returns (address);
-    // DSValue  public  pip;  // Reference price feed
     function pip() public view returns (address);
-    // DSValue  public  pep;  // Governance price feed
     function pep() public view returns (address);
-    // address  public  tap;  // Liquidator
     function tap() public view returns (address);
-    // address  public  pit;  // Governance Vault
     function pit() public view returns (address);
-    // uint256  public  axe;  // Liquidation penalty
     function axe() public view returns (uint256);
-    // uint256  public  cap;  // Debt ceiling
     function cap() public view returns (uint256);
-    // uint256  public  mat;  // Liquidation ratio
     function mat() public view returns (uint256);
-    // uint256  public  tax;  // Stability fee
     function tax() public view returns (uint256);
-    // uint256  public  fee;  // Governance fee
     function fee() public view returns (uint256);
-    // uint256  public  gap;  // Join-Exit Spread
     function gap() public view returns (uint256);
-    // bool     public  off;  // Cage flag
     function off() public view returns (bool);
-    // bool     public  out;  // Post cage exit
     function out() public view returns (bool);
-    // uint256  public  fit;  // REF per SKR (just before settlement)
     function fit() public view returns (uint256);
-    // uint256  public  rho;  // Time of last drip
     function rho() public view returns (uint256);
-    // uint256  public  rum;  // Total normalised debt
     function rum() public view returns (uint256);
-    // uint256  public  cupi;
     function cupi() public view returns (uint256);
-    // mapping (bytes32 => Cup)  public  cups;
     function cups(bytes32) public view returns (address, uint256, uint256, uint256);
     function lad(bytes32) public view returns (address);
     function ink(bytes32) public view returns (address);
     function tab(bytes32) public view returns (uint256);
     function rap(bytes32) public returns (uint256);
-    function din() public returns (uint256);            // Total CDP Debt
-    function air() public view returns (uint256);       // Backing collateral
-    function pie() public view returns (uint256);       // Raw collateral
+    function din() public returns (uint256);
+    function air() public view returns (uint256);
+    function pie() public view returns (uint256);
     function era() public view returns (uint256);
-    function mold(bytes32, uint256) public;             // Risk parameter config
-    function setPip(address) public;                    // Price feed setter
-    function setPep(address) public;                    // Price feed setter
-    function setVox(address) public;                    // Price feed setter
-    function turn(address) public;                      // Tap setter
-    function per() public view returns (uint256);       // Wrapper ratio (gem per skr)
-    function ask(uint256) public view returns (uint256);// Join price (gem per skr)
-    function bid(uint256) public view returns (uint256);// Exit price (gem per skr)
+    function mold(bytes32, uint256) public;
+    function setPip(address) public;
+    function setPep(address) public;
+    function setVox(address) public;
+    function turn(address) public;
+    function per() public view returns (uint256);
+    function ask(uint256) public view returns (uint256);
+    function bid(uint256) public view returns (uint256);
     function join(uint256) public;
     function exit(uint256) public;
     function chi() public returns (uint256);
     function rhi() public returns (uint256);
     function drip() public;
-    function tag() public view returns (uint256);       // Abstracted collateral price (ref per skr)
-    function safe(bytes32) public returns (bool);       // Returns true if cup is well-collateralized
+    function tag() public view returns (uint256);
+    function safe(bytes32) public returns (bool);
     function open() public returns (bytes32);
     function give(bytes32, address) public;
     function lock(bytes32, uint256) public;
@@ -81,10 +58,7 @@ contract SaiTubAbstract {
     function bite(bytes32) public;
     function cage(uint256, uint256) public;
     function flow() public;
-    // ds-thing
-    // DSAuthority  public  authority;
     function authority() public view returns (address);
-    // address      public  owner;
     function owner() public view returns (address);
     function setOwner(address) public;
     function setAuthority(address) public;

--- a/src/sai/SaiVoxAbstract.sol
+++ b/src/sai/SaiVoxAbstract.sol
@@ -7,15 +7,12 @@ contract SaiVoxAbstract {
     function tau() public view returns (uint256);
     function era() public view returns (uint256);
     function mold(bytes32, uint256) public;
-    function par() public returns (uint256);  // Dai Target Price (ref per dai)
+    function par() public returns (uint256);
     function way() public returns (uint256);
     function tell(uint256) public;
     function tune(uint256) public;
     function prod() public;
-    // ds-thing
-    // DSAuthority  public  authority;
     function authority() public view returns (address);
-    // address      public  owner;
     function owner() public view returns (address);
     function setOwner(address) public;
     function setAuthority(address) public;


### PR DESCRIPTION
This PR takes a hatchet to dss-interfaces. Removes comments, events, and structs that are inconsequential. The goal here is to provide only what's necessary to integrate with these contracts, which will ultimately provide a much cleaner output when etherscan verifying contracts that utilize this repo.