### PR TITLE
adding missing 4th file function on the kočka (cat)

### DIFF
--- a/src/dss/CatAbstract.sol
+++ b/src/dss/CatAbstract.sol
@@ -13,6 +13,7 @@ interface CatAbstract {
     function vow() external view returns (address);
     function file(bytes32, address) external;
     function file(bytes32, uint256) external;
+    function file(bytes32, uint256) external;
     function file(bytes32, bytes32, uint256) external;
     function file(bytes32, bytes32, address) external;
     function bite(bytes32, address) external returns (uint256);


### PR DESCRIPTION
cat missing `file(bytes32 what, uint256 data)` for updating the `box`