### PR TITLE
Add ChainlogHelper for making address accessible

### DIFF
--- a/src/Interfaces.sol
+++ b/src/Interfaces.sol
@@ -36,6 +36,7 @@ import { VatAbstract } from "./dss/VatAbstract.sol";
 import { VowAbstract } from "./dss/VowAbstract.sol";
 import { IlkRegistryAbstract } from "./dss/IlkRegistryAbstract.sol";
 import { ChainlogAbstract } from "./dss/ChainlogAbstract.sol";
+import { ChainlogHelper } from "./dss/ChainlogAbstract.sol";
 
 // Sai
 import { GemPitAbstract } from "./sai/GemPitAbstract.sol";

--- a/src/dss/ChainlogAbstract.sol
+++ b/src/dss/ChainlogAbstract.sol
@@ -22,10 +22,6 @@ interface ChainlogAbstract {
 // Helper function for returning address or abstract of Chainlog
 //  Valid on Mainnet, Kovan, Rinkeby, Ropsten, and Goerli
 contract ChainlogHelper {
-    function Address() external pure returns (address) {
-        return 0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F;
-    }
-    function Abstract() external pure returns (ChainlogAbstract) {
-        return ChainlogAbstract(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
-    }
+    address          public constant ADDRESS  = 0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F;
+    ChainlogAbstract public constant ABSTRACT = ChainlogAbstract(ADDRESS);
 }

--- a/src/dss/ChainlogAbstract.sol
+++ b/src/dss/ChainlogAbstract.sol
@@ -18,3 +18,14 @@ interface ChainlogAbstract {
     function list() external view returns (bytes32[] memory);
     function getAddress(bytes32) external view returns (address);
 }
+
+// Helper function for returning address or abstract of Chainlog
+//  Valid on Mainnet, Kovan, Rinkeby, Ropsten, and Goerli
+contract ChainlogHelper {
+    function Address() external pure returns (address) {
+        return 0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F;
+    }
+    function Abstract() external pure returns (ChainlogAbstract) {
+        return ChainlogAbstract(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
+    }
+}


### PR DESCRIPTION
Adds a contract `ChainlogHelper` that can be used to return the address or abstract of the chainlog. This allows access to the chainlog via `import` of the Chainlog Abstract, rather than requiring the user hard-code the address.