### PR TITLE
Add SPDX identifiers to interfaces

### DIFF
--- a/src/ERC/GemAbstract.sol
+++ b/src/ERC/GemAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // A base ERC-20 abstract class

--- a/src/Interfaces.sol
+++ b/src/Interfaces.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 import { GemAbstract } from "./ERC/GemAbstract.sol";

--- a/src/dapp/DSAuthorityAbstract.sol
+++ b/src/dapp/DSAuthorityAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/dapphub/ds-auth

--- a/src/dapp/DSChiefAbstract.sol
+++ b/src/dapp/DSChiefAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/dapphub/ds-chief

--- a/src/dapp/DSPauseAbstract.sol
+++ b/src/dapp/DSPauseAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/dapphub/ds-pause

--- a/src/dapp/DSPauseProxyAbstract.sol
+++ b/src/dapp/DSPauseProxyAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/dapphub/ds-pause

--- a/src/dapp/DSRolesAbstract.sol
+++ b/src/dapp/DSRolesAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/dapphub/ds-roles

--- a/src/dapp/DSRuneAbstract.sol
+++ b/src/dapp/DSRuneAbstract.sol
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss-spellbook

--- a/src/dapp/DSSpellAbstract.sol
+++ b/src/dapp/DSSpellAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/dapphub/ds-spell

--- a/src/dapp/DSThingAbstract.sol
+++ b/src/dapp/DSThingAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/dapphub/ds-thing

--- a/src/dapp/DSTokenAbstract.sol
+++ b/src/dapp/DSTokenAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/dapphub/ds-token/blob/master/src/token.sol

--- a/src/dapp/DSValueAbstract.sol
+++ b/src/dapp/DSValueAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/dapphub/ds-value/blob/master/src/value.sol

--- a/src/dss/AuthGemJoinAbstract.sol
+++ b/src/dss/AuthGemJoinAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss-deploy/blob/master/src/join.sol

--- a/src/dss/CatAbstract.sol
+++ b/src/dss/CatAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/cat.sol

--- a/src/dss/ChainlogAbstract.sol
+++ b/src/dss/ChainlogAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss-chain-log

--- a/src/dss/DaiAbstract.sol
+++ b/src/dss/DaiAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/dai.sol

--- a/src/dss/DaiJoinAbstract.sol
+++ b/src/dss/DaiJoinAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/join.sol

--- a/src/dss/DssAutoLineAbstract.sol
+++ b/src/dss/DssAutoLineAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss-auto-line/blob/master/src/DssAutoLine.sol

--- a/src/dss/ESMAbstract.sol
+++ b/src/dss/ESMAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/esm/blob/master/src/ESM.sol

--- a/src/dss/ETHJoinAbstract.sol
+++ b/src/dss/ETHJoinAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/join.sol

--- a/src/dss/EndAbstract.sol
+++ b/src/dss/EndAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/end.sol

--- a/src/dss/FaucetAbstract.sol
+++ b/src/dss/FaucetAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/token-faucet/blob/master/src/RestrictedTokenFaucet.sol

--- a/src/dss/FlapAbstract.sol
+++ b/src/dss/FlapAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/flap.sol

--- a/src/dss/FlipAbstract.sol
+++ b/src/dss/FlipAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/flip.sol

--- a/src/dss/FlipperMomAbstract.sol
+++ b/src/dss/FlipperMomAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/flipper-mom/blob/master/src/FlipperMom.sol

--- a/src/dss/FlopAbstract.sol
+++ b/src/dss/FlopAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/flop.sol

--- a/src/dss/GemJoinAbstract.sol
+++ b/src/dss/GemJoinAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/join.sol

--- a/src/dss/GemJoinImplementationAbstract.sol
+++ b/src/dss/GemJoinImplementationAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss-deploy/blob/master/src/join.sol

--- a/src/dss/IlkRegistryAbstract.sol
+++ b/src/dss/IlkRegistryAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/ilk-registry

--- a/src/dss/JugAbstract.sol
+++ b/src/dss/JugAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/jug.sol

--- a/src/dss/MKRAbstract.sol
+++ b/src/dss/MKRAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 import { DSTokenAbstract } from "../dapp/DSTokenAbstract.sol";

--- a/src/dss/MedianAbstract.sol
+++ b/src/dss/MedianAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/median

--- a/src/dss/MkrAuthorityAbstract.sol
+++ b/src/dss/MkrAuthorityAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/mkr-authority/blob/master/src/MkrAuthority.sol

--- a/src/dss/OsmAbstract.sol
+++ b/src/dss/OsmAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/osm

--- a/src/dss/OsmMomAbstract.sol
+++ b/src/dss/OsmMomAbstract.sol
@@ -1,5 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
-
 
 // https://github.com/makerdao/osm-mom
 interface OsmMomAbstract {

--- a/src/dss/PipAbstract.sol
+++ b/src/dss/PipAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 import { DSValueAbstract } from "../dapp/DSValueAbstract.sol";

--- a/src/dss/PotAbstract.sol
+++ b/src/dss/PotAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/pot.sol

--- a/src/dss/PotHelper.sol
+++ b/src/dss/PotHelper.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 import { PotAbstract } from "./PotAbstract.sol";

--- a/src/dss/SpotAbstract.sol
+++ b/src/dss/SpotAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/spot.sol

--- a/src/dss/VatAbstract.sol
+++ b/src/dss/VatAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/vat.sol

--- a/src/dss/VowAbstract.sol
+++ b/src/dss/VowAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/dss/blob/master/src/vow.sol

--- a/src/sai/GemPitAbstract.sol
+++ b/src/sai/GemPitAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/sai/blob/master/src/pit.sol

--- a/src/sai/SaiMomAbstract.sol
+++ b/src/sai/SaiMomAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/sai/blob/master/src/mom.sol

--- a/src/sai/SaiTapAbstract.sol
+++ b/src/sai/SaiTapAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/sai/blob/master/src/tap.sol

--- a/src/sai/SaiTokenAbstract.sol
+++ b/src/sai/SaiTokenAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 import { DSTokenAbstract } from "../dapp/DSTokenAbstract.sol";

--- a/src/sai/SaiTopAbstract.sol
+++ b/src/sai/SaiTopAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/sai/blob/master/src/top.sol

--- a/src/sai/SaiTubAbstract.sol
+++ b/src/sai/SaiTubAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/sai/blob/master/src/tub.sol

--- a/src/sai/SaiVoxAbstract.sol
+++ b/src/sai/SaiVoxAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/sai/blob/master/src/vox.sol


### PR DESCRIPTION
Cleans up some warnings when compiled with later versions of solc.