### PR TITLE
Fix Lerp `tick` Interface

### DIFF
--- a/src/dss/LerpAbstract.sol
+++ b/src/dss/LerpAbstract.sol
@@ -10,6 +10,6 @@ interface LerpAbstract {
     function duration() external view returns (uint256);
     function done() external view returns (bool);
     function startTime() external view returns (uint256);
-    function tick() external;
+    function tick() external returns (uint256);
     function ilk() external view returns (bytes32);
 }

--- a/src/dss/LerpFactoryAbstract.sol
+++ b/src/dss/LerpFactoryAbstract.sol
@@ -7,7 +7,7 @@ interface LerpFactoryAbstract {
     function rely(address) external;
     function deny(address) external;
     function lerps(bytes32) external view returns (address);
-    function active(uint256) external view returns (address);
+    function active(uint256) external view returns (address[] memory);
     function newLerp(bytes32, address, bytes32, uint256, uint256, uint256, uint256) external view returns (address);
     function newIlkLerp(bytes32, address, bytes32, bytes32, uint256, uint256, uint256, uint256) external view returns (address);
     function tall() external;

--- a/src/dss/LerpFactoryAbstract.sol
+++ b/src/dss/LerpFactoryAbstract.sol
@@ -7,7 +7,7 @@ interface LerpFactoryAbstract {
     function rely(address) external;
     function deny(address) external;
     function lerps(bytes32) external view returns (address);
-    function active(uint256) external view returns (address[] memory);
+    function active(uint256) external view returns (address);
     function newLerp(bytes32, address, bytes32, uint256, uint256, uint256, uint256) external view returns (address);
     function newIlkLerp(bytes32, address, bytes32, bytes32, uint256, uint256, uint256, uint256) external view returns (address);
     function tall() external;


### PR DESCRIPTION
- Add Lerp missing `tick` return value.
- ~Fix LerpFactory `active` return value~ 