### PR TITLE
Fix Jug base() return type

### DIFF
--- a/src/dss/JugAbstract.sol
+++ b/src/dss/JugAbstract.sol
@@ -9,7 +9,7 @@ interface JugAbstract {
     function ilks(bytes32) external view returns (uint256, uint256);
     function vat() external view returns (address);
     function vow() external view returns (address);
-    function base() external view returns (address);
+    function base() external view returns (uint256);
     function init(bytes32) external;
     function file(bytes32, bytes32, uint256) external;
     function file(bytes32, uint256) external;


### PR DESCRIPTION
From the [implementation](https://github.com/makerdao/dss/blob/c666ab1fdac4cb3dd8a8b4223f951a9773a64c55/src/jug.sol#L53), the base is not of type `address`, but `uint256`.