### PR TITLE
Move `PotHelper` contract to `utils` folder

### DIFF
--- a/src/Interfaces.sol
+++ b/src/Interfaces.sol
@@ -51,7 +51,7 @@ import { MedianAbstract } from "./dss/MedianAbstract.sol";
 import { OsmAbstract } from "./dss/OsmAbstract.sol";
 import { OsmMomAbstract } from "./dss/OsmMomAbstract.sol";
 import { PotAbstract } from "./dss/PotAbstract.sol";
-import { PotHelper } from "./dss/PotHelper.sol";
+import { PotHelper } from "./utils/PotHelper.sol";
 import { PsmAbstract } from "./dss/PsmAbstract.sol";
 import { SpotAbstract } from "./dss/SpotAbstract.sol";
 import { StairstepExponentialDecreaseAbstract } from "./dss/StairstepExponentialDecreaseAbstract.sol";

--- a/src/utils/PotHelper.sol
+++ b/src/utils/PotHelper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.5.12;
 
-import { PotAbstract } from "./PotAbstract.sol";
+import { PotAbstract } from "../dss/PotAbstract.sol";
 
 // https://github.com/makerdao/dss/blob/master/src/pot.sol
 contract PotHelper {


### PR DESCRIPTION
- Move `PotHelper` contract to `utils` folder for now, pending discussion on moving it to an external repo or deploying it on mainnet.