### PR TITLE
Add MIP21 contracts interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /out
+/cache

--- a/src/Interfaces.sol
+++ b/src/Interfaces.sol
@@ -59,10 +59,20 @@ import { VestAbstract } from "./dss/VestAbstract.sol";
 import { VowAbstract } from "./dss/VowAbstract.sol";
 
 // MIP21 Abstracts
-import { RwaInputConduitBaseAbstract, RwaInputConduitAbstract, RwaInputConduit2Abstract } from "./dss/mip21/RwaInputConduitAbstract.sol";
+import {
+  RwaInputConduitBaseAbstract,
+  RwaInputConduitAbstract,
+  RwaInputConduit2Abstract,
+  RwaInputConduit3Abstract
+} from "./dss/mip21/RwaInputConduitAbstract.sol";
 import { RwaJarAbstract } from "./dss/mip21/RwaJarAbstract.sol";
 import { RwaLiquidationOracleAbstract } from "./dss/mip21/RwaLiquidationOracleAbstract.sol";
-import { RwaOutputConduitBaseAbstract, RwaOutputConduitAbstract, RwaOutputConduit2Abstract } from "./dss/mip21/RwaOutputConduitAbstract.sol";
+import {
+  RwaOutputConduitBaseAbstract,
+  RwaOutputConduitAbstract,
+  RwaOutputConduit2Abstract,
+  RwaOutputConduit3Abstract
+} from "./dss/mip21/RwaOutputConduitAbstract.sol";
 import { RwaUrnAbstract } from "./dss/mip21/RwaUrnAbstract.sol";
 
 import { GemPitAbstract } from "./sai/GemPitAbstract.sol";

--- a/src/Interfaces.sol
+++ b/src/Interfaces.sol
@@ -58,6 +58,13 @@ import { VatAbstract } from "./dss/VatAbstract.sol";
 import { VestAbstract } from "./dss/VestAbstract.sol";
 import { VowAbstract } from "./dss/VowAbstract.sol";
 
+// MIP21 Abstracts
+import { RwaInputConduitBaseAbstract, RwaInputConduitAbstract, RwaInputConduit2Abstract } from "./dss/mip21/RwaInputConduitAbstract.sol";
+import { RwaJarAbstract } from "./dss/mip21/RwaJarAbstract.sol";
+import { RwaLiquidationOracleAbstract } from "./dss/mip21/RwaLiquidationOracleAbstract.sol";
+import { RwaOutputConduitBaseAbstract, RwaOutputConduitAbstract, RwaOutputConduit2Abstract } from "./dss/mip21/RwaOutputConduitAbstract.sol";
+import { RwaUrnAbstract } from "./dss/mip21/RwaUrnAbstract.sol";
+
 import { GemPitAbstract } from "./sai/GemPitAbstract.sol";
 import { SaiMomAbstract } from "./sai/SaiMomAbstract.sol";
 import { SaiTapAbstract } from "./sai/SaiTapAbstract.sol";

--- a/src/dss/mip21/RwaInputConduitAbstract.sol
+++ b/src/dss/mip21/RwaInputConduitAbstract.sol
@@ -8,12 +8,12 @@ interface RwaInputConduitBaseAbstract {
     function push() external;
 }
 
-// https://github.com/clio-finance/mip21-toolkit/blob/master/src/conduits/RwaInputConduit.sol
+// https://github.com/makerdao/mip21-toolkit/blob/master/src/conduits/RwaInputConduit.sol
 interface RwaInputConduitAbstract is RwaInputConduitBaseAbstract {
     function gov() external view returns (address);
 }
 
-// https://github.com/clio-finance/mip21-toolkit/blob/master/src/conduits/RwaInputConduit2.sol
+// https://github.com/makerdao/mip21-toolkit/blob/master/src/conduits/RwaInputConduit2.sol
 interface RwaInputConduit2Abstract is RwaInputConduitBaseAbstract {
     function wards(address) external view returns (uint256);
     function rely(address) external;

--- a/src/dss/mip21/RwaInputConduitAbstract.sol
+++ b/src/dss/mip21/RwaInputConduitAbstract.sol
@@ -23,3 +23,22 @@ interface RwaInputConduit2Abstract is RwaInputConduitBaseAbstract {
     function hate(address) external;
 }
 
+// https://github.com/makerdao/mip21-toolkit/blob/master/src/conduits/RwaInputConduit3.sol
+interface RwaInputConduit3Abstract is RwaInputConduitBaseAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function may(address) external view returns (uint256);
+    function mate(address) external;
+    function hate(address) external;
+    function psm() external view returns (address);
+    function gem() external view returns (address);
+    function quitTo() external view returns (address);
+    function file(bytes32, address) external;
+    function push(uint) external;
+    function quit() external;
+    function quit(uint) external;
+    function yank(address, address, uint256) external;
+    function expectedDaiWad(uint256) external view returns (uint256);
+    function requiredGemAmt(uint256) external view returns (uint256);
+}

--- a/src/dss/mip21/RwaInputConduitAbstract.sol
+++ b/src/dss/mip21/RwaInputConduitAbstract.sol
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+interface RwaInputConduitBaseAbstract {
+    function dai() external view returns (address);
+    function to() external view returns (address);
+    function push() external;
+}
+
+// https://github.com/clio-finance/mip21-toolkit/blob/master/src/conduits/RwaInputConduit.sol
+interface RwaInputConduitAbstract is RwaInputConduitBaseAbstract {
+    function gov() external view returns (address);
+}
+
+// https://github.com/clio-finance/mip21-toolkit/blob/master/src/conduits/RwaInputConduit2.sol
+interface RwaInputConduit2Abstract is RwaInputConduitBaseAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function may(address) external view returns (uint256);
+    function mate(address) external;
+    function hate(address) external;
+}
+

--- a/src/dss/mip21/RwaJarAbstract.sol
+++ b/src/dss/mip21/RwaJarAbstract.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.5.12;
 
-// https://github.com/clio-finance/mip21-toolkit/blob/master/src/jars/RwaJar.sol
+// https://github.com/makerdao/mip21-toolkit/blob/master/src/jars/RwaJar.sol
 interface RwaJarAbstract {
     function daiJoin() external view returns(address);
     function dai() external view returns(address);

--- a/src/dss/mip21/RwaJarAbstract.sol
+++ b/src/dss/mip21/RwaJarAbstract.sol
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/clio-finance/mip21-toolkit/blob/master/src/jars/RwaJar.sol
+interface RwaJarAbstract {
+    function daiJoin() external view returns(address);
+    function dai() external view returns(address);
+    function chainlog() external view returns(address);
+    function void() external;
+    function toss(uint256) external;
+}

--- a/src/dss/mip21/RwaLiquidationOracleAbstract.sol
+++ b/src/dss/mip21/RwaLiquidationOracleAbstract.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.5.12;
 
-// https://github.com/clio-finance/mip21-toolkit/blob/master/src/oracles/RwaLiquidationOracle.sol
+// https://github.com/makerdao/mip21-toolkit/blob/master/src/oracles/RwaLiquidationOracle.sol
 interface RwaLiquidationOracleAbstract {
     function wards(address) external view returns (uint256);
     function rely(address) external;

--- a/src/dss/mip21/RwaLiquidationOracleAbstract.sol
+++ b/src/dss/mip21/RwaLiquidationOracleAbstract.sol
@@ -15,6 +15,6 @@ interface RwaLiquidationOracleAbstract {
     function bump(bytes32, uint256) external;
     function tell(bytes32) external;
     function cure(bytes32) external;
-    function cull(bytes32) external;
+    function cull(bytes32, address) external;
     function good(bytes32) external view returns (bool);
 }

--- a/src/dss/mip21/RwaLiquidationOracleAbstract.sol
+++ b/src/dss/mip21/RwaLiquidationOracleAbstract.sol
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/clio-finance/mip21-toolkit/blob/master/src/oracles/RwaLiquidationOracle.sol
+interface RwaLiquidationOracleAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function vat() external view returns (address);
+    function vow() external view returns (address);
+    function ilks(bytes32) external view returns(string memory, address, uint48, uint48);
+    function file(bytes32, address) external;
+    function init(bytes32, uint256, string calldata, uint48) external;
+    function bump(bytes32, uint256) external;
+    function tell(bytes32) external;
+    function cure(bytes32) external;
+    function cull(bytes32) external;
+    function good(bytes32) external view returns (bool);
+}

--- a/src/dss/mip21/RwaOutputConduitAbstract.sol
+++ b/src/dss/mip21/RwaOutputConduitAbstract.sol
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+interface RwaOutputConduitBaseAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function can(address) external view returns (uint256);
+    function hope(address) external;
+    function nope(address) external;
+    function dai() external view returns (address);
+    function to() external view returns (address);
+    function bud(address) external view returns (uint256);
+    function kiss(address) external;
+    function diss(address) external;
+    function pick(address) external;
+    function push() external;
+}
+
+// https://github.com/clio-finance/mip21-toolkit/blob/master/src/conduits/RwaOutputConduit.sol
+interface RwaOutputConduitAbstract is RwaOutputConduitBaseAbstract {
+    function gov() external view returns (address);
+}
+
+// https://github.com/clio-finance/mip21-toolkit/blob/master/src/conduits/RwaOutputConduit2.sol
+interface RwaOutputConduit2Abstract is RwaOutputConduitBaseAbstract {
+    function may(address) external view returns (uint256);
+    function mate(address) external;
+    function hate(address) external;
+}

--- a/src/dss/mip21/RwaOutputConduitAbstract.sol
+++ b/src/dss/mip21/RwaOutputConduitAbstract.sol
@@ -11,9 +11,6 @@ interface RwaOutputConduitBaseAbstract {
     function nope(address) external;
     function dai() external view returns (address);
     function to() external view returns (address);
-    function bud(address) external view returns (uint256);
-    function kiss(address) external;
-    function diss(address) external;
     function pick(address) external;
     function push() external;
 }
@@ -21,6 +18,9 @@ interface RwaOutputConduitBaseAbstract {
 // https://github.com/makerdao/mip21-toolkit/blob/master/src/conduits/RwaOutputConduit.sol
 interface RwaOutputConduitAbstract is RwaOutputConduitBaseAbstract {
     function gov() external view returns (address);
+    function bud(address) external view returns (uint256);
+    function kiss(address) external;
+    function diss(address) external;
 }
 
 // https://github.com/makerdao/mip21-toolkit/blob/master/src/conduits/RwaOutputConduit2.sol
@@ -28,4 +28,24 @@ interface RwaOutputConduit2Abstract is RwaOutputConduitBaseAbstract {
     function may(address) external view returns (uint256);
     function mate(address) external;
     function hate(address) external;
+}
+
+// https://github.com/makerdao/mip21-toolkit/blob/master/src/conduits/RwaOutputConduit3.sol
+interface RwaOutputConduit3Abstract is RwaOutputConduitBaseAbstract {
+    function bud(address) external view returns (uint256);
+    function kiss(address) external;
+    function diss(address) external;
+    function may(address) external view returns (uint256);
+    function mate(address) external;
+    function hate(address) external;
+    function psm() external view returns (address);
+    function gem() external view returns (address);
+    function quitTo() external view returns (address);
+    function file(bytes32, address) external;
+    function push(uint) external;
+    function quit() external;
+    function quit(uint) external;
+    function yank(address, address, uint256) external;
+    function expectedGemAmt(uint256) external view returns (uint256);
+    function requiredDaiWad(uint256) external view returns (uint256);
 }

--- a/src/dss/mip21/RwaOutputConduitAbstract.sol
+++ b/src/dss/mip21/RwaOutputConduitAbstract.sol
@@ -18,12 +18,12 @@ interface RwaOutputConduitBaseAbstract {
     function push() external;
 }
 
-// https://github.com/clio-finance/mip21-toolkit/blob/master/src/conduits/RwaOutputConduit.sol
+// https://github.com/makerdao/mip21-toolkit/blob/master/src/conduits/RwaOutputConduit.sol
 interface RwaOutputConduitAbstract is RwaOutputConduitBaseAbstract {
     function gov() external view returns (address);
 }
 
-// https://github.com/clio-finance/mip21-toolkit/blob/master/src/conduits/RwaOutputConduit2.sol
+// https://github.com/makerdao/mip21-toolkit/blob/master/src/conduits/RwaOutputConduit2.sol
 interface RwaOutputConduit2Abstract is RwaOutputConduitBaseAbstract {
     function may(address) external view returns (uint256);
     function mate(address) external;

--- a/src/dss/mip21/RwaTokenFactoryAbstract.sol
+++ b/src/dss/mip21/RwaTokenFactoryAbstract.sol
@@ -4,10 +4,6 @@ pragma solidity >=0.5.12;
 
 // https://github.com/makerdao/mip21-toolkit/blob/master/src/tokens/RwaTokenFactory.sol
 interface RwaTokenFactoryAbstract {
-    function createRwaToken(
-        string calldata name,
-        string calldata symbol,
-        address recipient
-    ) external returns (address);
+    function createRwaToken(string calldata, string calldata, address) external returns (address);
 }
 

--- a/src/dss/mip21/RwaTokenFactoryAbstract.sol
+++ b/src/dss/mip21/RwaTokenFactoryAbstract.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.5.12;
 
-// https://github.com/clio-finance/mip21-toolkit/blob/master/src/tokens/RwaTokenFactory.sol
+// https://github.com/makerdao/mip21-toolkit/blob/master/src/tokens/RwaTokenFactory.sol
 interface RwaTokenFactoryAbstract {
     function createRwaToken(
         string calldata name,

--- a/src/dss/mip21/RwaTokenFactoryAbstract.sol
+++ b/src/dss/mip21/RwaTokenFactoryAbstract.sol
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/clio-finance/mip21-toolkit/blob/master/src/tokens/RwaTokenFactory.sol
+interface RwaTokenFactoryAbstract {
+    function createRwaToken(
+        string calldata name,
+        string calldata symbol,
+        address recipient
+    ) external returns (address);
+}
+

--- a/src/dss/mip21/RwaUrnAbstract.sol
+++ b/src/dss/mip21/RwaUrnAbstract.sol
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/clio-finance/mip21-toolkit/blob/master/src/urns/RwaUrn.sol
+// https://github.com/clio-finance/mip21-toolkit/blob/master/src/urns/RwaUrn2.sol
+interface RwaUrnAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function can(address) external view returns (uint256);
+    function hope(address) external;
+    function nope(address) external;
+    function vat() external view returns (address);
+    function jug() external view returns (address);
+    function gemJoin() external view returns (address);
+    function daiJoin() external view returns (address);
+    function outputConduit() external view returns (address);
+    function file(bytes32, address) external;
+    function lock(uint256) external;
+    function draw(uint256) external;
+    function wipe(uint256) external;
+    function free(uint256) external;
+    function quit() external;
+}

--- a/src/dss/mip21/RwaUrnAbstract.sol
+++ b/src/dss/mip21/RwaUrnAbstract.sol
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.5.12;
 
-// https://github.com/clio-finance/mip21-toolkit/blob/master/src/urns/RwaUrn.sol
-// https://github.com/clio-finance/mip21-toolkit/blob/master/src/urns/RwaUrn2.sol
+// https://github.com/makerdao/mip21-toolkit/blob/master/src/urns/RwaUrn.sol
+// https://github.com/makerdao/mip21-toolkit/blob/master/src/urns/RwaUrn2.sol
 interface RwaUrnAbstract {
     function wards(address) external view returns (uint256);
     function rely(address) external;


### PR DESCRIPTION
Adds the interfaces for MIP21 contracts from the [`mip21-toolkit`](https://github.com/clio-finance/mip21-toolkit) repo.

**NOTICE**: `clio-finance/mip21-toolkit` will be moved to `makerdao/mip21-toolkit` shortly. GitHub will handle redirections for a while, however we will need to come back and update the references to the contract files when that is done.
